### PR TITLE
About page hover-out removal

### DIFF
--- a/views/static/js/about.js
+++ b/views/static/js/about.js
@@ -2,8 +2,6 @@ $(document).ready(function() {
 
 	$('#list-images li img').hover(function() {
 		$('#description').html($(this).next().html());
-	}, function() {
-		$('#description').html('');
 	});
 
 });


### PR DESCRIPTION
The About page stutters when displayed below a certain width because hover-out removes descriptions. This fix keeps the descriptions on the page even after hover-out. No more stutter and scrolling up and down once again works. Tested on MAC OSX + Windows 8.1: Chrome for both. Also may help mobile but not 100% sure how mobile uses hover states.